### PR TITLE
prevent HttpPing from crashing on GuzzleHttp\Exception\ServerException

### DIFF
--- a/src/Monitors/HttpPingMonitor.php
+++ b/src/Monitors/HttpPingMonitor.php
@@ -76,6 +76,8 @@ class HttpPingMonitor extends BaseMonitor
             $this->responseContent = (string)$response->getBody();
         } catch (\Exception $e) {
             // To prevent command from crashing and let Notifier handle this
+            $this->responseCode = 500;
+            $this->responseContent = $e->getMessage() . PHP_EOL . $e->getTraceAsString();
         }
 
         if ($this->responseCode != '200'

--- a/src/Monitors/HttpPingMonitor.php
+++ b/src/Monitors/HttpPingMonitor.php
@@ -78,14 +78,11 @@ class HttpPingMonitor extends BaseMonitor
                 $this->responseCode = $response->getStatusCode();
                 $this->responseContent = (string)$response->getBody();
             } else {
-                $this->responseCode = 500;
-                $this->responseContent = $e->getMessage() . PHP_EOL . $e->getTraceAsString();
+                $this->setResponseCodeAndContentOnException($e);
             }
 
         } catch (\Exception $e) {
-            // To prevent command from crashing and let Notifier handle this
-            $this->responseCode = 500;
-            $this->responseContent = $e->getMessage() . PHP_EOL . $e->getTraceAsString();
+            $this->setResponseCodeAndContentOnException($e);
         }
 
         if ($this->responseCode != '200'
@@ -94,6 +91,15 @@ class HttpPingMonitor extends BaseMonitor
         } else {
             event(new HttpPingUp($this));
         }
+    }
+
+    /**
+     * @param \Exception $e
+     */
+    protected function setResponseCodeAndContentOnException(\Exception $e)
+    {
+        $this->responseCode = null;
+        $this->responseContent = $e->getMessage() . PHP_EOL . $e->getTraceAsString();
     }
 
     protected function checkResponseContains($html, $phrase)

--- a/src/Monitors/HttpPingMonitor.php
+++ b/src/Monitors/HttpPingMonitor.php
@@ -6,8 +6,7 @@ use EricMakesStuff\ServerMonitor\Events\HttpPingDown;
 use EricMakesStuff\ServerMonitor\Events\HttpPingUp;
 use EricMakesStuff\ServerMonitor\Exceptions\InvalidConfiguration;
 use GuzzleHttp\Client as Guzzle;
-use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
 
 class HttpPingMonitor extends BaseMonitor
 {
@@ -71,10 +70,12 @@ class HttpPingMonitor extends BaseMonitor
             $response = $guzzle->get($this->url);
             $this->responseCode = $response->getStatusCode();
             $this->responseContent = (string)$response->getBody();
-        } catch (ClientException $e) {
+        } catch (RequestException $e) {
             $response = $e->getResponse();
             $this->responseCode = $response->getStatusCode();
-        } catch (ConnectException $e) {
+            $this->responseContent = (string)$response->getBody();
+        } catch (\Exception $e) {
+            // To prevent command from crashing and let Notifier handle this
         }
 
         if ($this->responseCode != '200'

--- a/src/Monitors/HttpPingMonitor.php
+++ b/src/Monitors/HttpPingMonitor.php
@@ -7,6 +7,7 @@ use EricMakesStuff\ServerMonitor\Events\HttpPingUp;
 use EricMakesStuff\ServerMonitor\Exceptions\InvalidConfiguration;
 use GuzzleHttp\Client as Guzzle;
 use GuzzleHttp\Exception\RequestException;
+use Psr\Http\Message\ResponseInterface;
 
 class HttpPingMonitor extends BaseMonitor
 {
@@ -72,8 +73,15 @@ class HttpPingMonitor extends BaseMonitor
             $this->responseContent = (string)$response->getBody();
         } catch (RequestException $e) {
             $response = $e->getResponse();
-            $this->responseCode = $response->getStatusCode();
-            $this->responseContent = (string)$response->getBody();
+
+            if ($response instanceof ResponseInterface) {
+                $this->responseCode = $response->getStatusCode();
+                $this->responseContent = (string)$response->getBody();
+            } else {
+                $this->responseCode = 500;
+                $this->responseContent = $e->getMessage() . PHP_EOL . $e->getTraceAsString();
+            }
+
         } catch (\Exception $e) {
             // To prevent command from crashing and let Notifier handle this
             $this->responseCode = 500;


### PR DESCRIPTION
HttpPingMonitor crashes when server returns 5xx errors (Guzzle throws ServerException that is not handled)