### PR TITLE
allow to use closure in the monitors confg

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,21 @@ The default monitor configurations are:
     ],
 ```
 
+Optionally you can define configurations as anonymous functions. For example
+
+```php
+'monitors' => [
+    'HttpPing' => function(){
+        return \App\Models\Domain::all()->map(function(\App\Models\Domain $domain){
+            return [
+                'url'=>$domain->url,
+                'checkPhrase'=>$domain->check_phrase,
+            ];
+        })->toArray();
+    },
+]
+```
+
 ## Alert Configuration
 
 Alerts can be logged to the default log handler, or sent via email, Pushover, or Slack. Allowed values are `log`, `mail`, `pushover`, and `slack`.

--- a/src/Monitors/ServerMonitorFactory.php
+++ b/src/Monitors/ServerMonitorFactory.php
@@ -22,6 +22,10 @@ class ServerMonitorFactory
         $configured_monitors = collect();
 
         $monitors->map(function($monitorConfigs, $monitorName) {
+            if ($monitorConfigs instanceof \Closure) {
+                $monitorConfigs = call_user_func($monitorConfigs);
+            }
+            
             if (file_exists(__DIR__.'/'.ucfirst($monitorName).'Monitor.php')) {
                 $className = '\\EricMakesStuff\\ServerMonitor\\Monitors\\'.ucfirst($monitorName).'Monitor';
                 return collect($monitorConfigs)->map(function($monitorConfig) use ($className) {


### PR DESCRIPTION
Sometimes you want to get list of domains for monitor configuration from external source (e.g. database)