### PR TITLE
Update for laravel 5.6

### DIFF
--- a/src/Notifications/Notifier.php
+++ b/src/Notifications/Notifier.php
@@ -4,7 +4,7 @@ namespace EricMakesStuff\ServerMonitor\Notifications;
 
 use EricMakesStuff\ServerMonitor\Monitors\HttpPingMonitor;
 use EricMakesStuff\ServerMonitor\Monitors\SSLCertificateMonitor;
-use Illuminate\Contracts\Logging\Log as LogContract;
+use Psr\Log\LoggerInterface as LogContract;
 use EricMakesStuff\ServerMonitor\Monitors\DiskUsageMonitor;
 use Exception;
 
@@ -13,13 +13,13 @@ class Notifier
     /** @var array */
     protected $config;
 
-    /** @var \Illuminate\Contracts\Logging\Log */
+    /** @var \Psr\Log\LoggerInterface */
     protected $log;
 
     protected $serverName;
 
     /**
-     * @param \Illuminate\Contracts\Logging\Log $log
+     * @param \Psr\Log\LoggerInterface $log
      */
     public function __construct(LogContract $log)
     {

--- a/src/Notifications/Senders/Log.php
+++ b/src/Notifications/Senders/Log.php
@@ -2,16 +2,16 @@
 
 namespace EricMakesStuff\ServerMonitor\Notifications\Senders;
 
-use Illuminate\Contracts\Logging\Log as LogContract;
+use Psr\Log\LoggerInterface as LogContract;
 use EricMakesStuff\ServerMonitor\Notifications\BaseSender;
 
 class Log extends BaseSender
 {
-    /** @var \Illuminate\Contracts\Logging\Log */
+    /** @var \Psr\Log\LoggerInterface */
     protected $log;
 
     /**
-     * @param \Illuminate\Contracts\Logging\Log $log
+     * @param \Psr\Log\LoggerInterface $log
      */
     public function __construct(LogContract $log)
     {


### PR DESCRIPTION
This interface has been removed since this interface was a total duplication of the  `Psr\Log\LoggerInterface` interface. You should type-hint the` Psr\Log\LoggerInterface` interface instead.